### PR TITLE
Phase 2: add Glean stub fixtures and tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## Phase 2 – Rich stub fixtures integrated; search tool now grounded in realistic metadata.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ uv sync
 # volcengine TTS: Add your TTS credentials if you have them
 cp .env.example .env
 
+# Fixture-based stub mode is enabled by default. Leave `USE_GLEAN_STUB=true` in
+# your `.env` file to load search results from `tests/fixtures/glean/` instead of
+# making real Glean API calls.
+
 # See the 'Supported Search Engines' and 'Text-to-Speech Integration' sections below for all available options
 
 # Configure conf.yaml for your LLM model and API keys

--- a/docs/design/0001-table-deep-research-agent.md
+++ b/docs/design/0001-table-deep-research-agent.md
@@ -87,6 +87,25 @@ Key points:
 * `tests/fixtures/glean/` for stub data
 * CI pipeline in `.github/workflows/ci.yml`
 
+### Fixture Schema
+
+Stub search results live under `tests/fixtures/glean/`. Each file is named
+`<table_name>.json` and contains an array of documents. Every document carries
+these mandatory fields:
+
+```
+doc_id        # unique across the corpus
+title         # human readable title
+doc_type      # schema | wiki | dashboard | runbook | lineage | notebook
+table_name    # the table it references
+description   # short summary
+tags          # list of strings
+url           # link to the source (Confluence, Grafana, etc.)
+```
+
+Optional blocks (e.g. `columns`, `lineage`, `metrics`, `sample_query`) add
+realism so later agents can reason about freshness or popularity.
+
 ---
 
 > **Note**: This ADR is a concise snapshot of the TDR Agents context and the key architecture choices. For detailed implementation steps (including code snippets, prompts, node definitions), refer to the “Table-Deep-Research Agent — Detailed Design & Implementation Guide” and your repository’s `src/my_agents/table_research/` folder.

--- a/src/my_agents/table_research/tools/__init__.py
+++ b/src/my_agents/table_research/tools/__init__.py
@@ -1,2 +1,5 @@
-# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
-# SPDX-License-Identifier: MIT
+"""Tools for table research module."""
+
+from .glean_search import GleanSearch
+
+__all__ = ["GleanSearch"]

--- a/src/my_agents/table_research/tools/glean_search.py
+++ b/src/my_agents/table_research/tools/glean_search.py
@@ -1,0 +1,31 @@
+"""Stub search tool for loading table documents from local fixtures."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+class GleanSearch:
+    """Load search results from JSON fixtures when stub mode is enabled."""
+
+    def __init__(self, fixtures_dir: Path | None = None) -> None:
+        self.fixtures_dir = fixtures_dir or Path("tests/fixtures/glean")
+
+    def search(self, table_name: str, top_k: int | None = None) -> list[dict[str, Any]]:
+        """Return search hits for the given table from fixture files."""
+        if os.getenv("USE_GLEAN_STUB", "true").lower() != "true":
+            raise RuntimeError("GleanSearch stub active but USE_GLEAN_STUB!=true")
+
+        file_path = self.fixtures_dir / f"{table_name}.json"
+        if not file_path.exists():
+            raise FileNotFoundError(f"Fixture not found for table: {table_name}")
+
+        with file_path.open("r", encoding="utf-8") as f:
+            docs: list[dict[str, Any]] = json.load(f)
+
+        if top_k is not None:
+            return docs[:top_k]
+        return docs

--- a/tests/fixtures/glean/event.FunnelStep.json
+++ b/tests/fixtures/glean/event.FunnelStep.json
@@ -1,0 +1,50 @@
+[
+  {
+    "doc_id": "event.FunnelStep.schema",
+    "title": "event.FunnelStep Schema",
+    "doc_type": "schema",
+    "table_name": "event.FunnelStep",
+    "description": "Schema for funnel step events",
+    "tags": ["event"],
+    "url": "https://confluence.example.com/event/FunnelStep/schema",
+    "author": "event_team",
+    "created_at": "2024-04-01",
+    "last_updated": "2024-05-20",
+    "row_count": 150000,
+    "columns": [
+      {"name": "session_id", "type": "STRING", "description": "Session"},
+      {"name": "step", "type": "INT", "description": "Step"},
+      {"name": "timestamp", "type": "TIMESTAMP", "description": "Step time"}
+    ],
+    "sample_query": "SELECT step, COUNT(*) FROM event.FunnelStep GROUP BY step"
+  },
+  {
+    "doc_id": "event.FunnelStep.wiki",
+    "title": "FunnelStep Wiki",
+    "doc_type": "wiki",
+    "table_name": "event.FunnelStep",
+    "description": "Funnel step documentation",
+    "tags": ["event", "reference"],
+    "url": "https://confluence.example.com/event/FunnelStep/wiki",
+    "author": "event_ops",
+    "created_at": "2024-04-10",
+    "last_updated": "2024-05-25",
+    "sample_query": "SELECT COUNT(*) FROM event.FunnelStep"
+  },
+  {
+    "doc_id": "event.FunnelStep.lineage",
+    "title": "FunnelStep Lineage",
+    "doc_type": "lineage",
+    "table_name": "event.FunnelStep",
+    "description": "Lineage for funnel step",
+    "tags": ["lineage"],
+    "url": "https://confluence.example.com/event/FunnelStep/lineage",
+    "author": "data_engineer4",
+    "created_at": "2024-04-05",
+    "last_updated": "2024-06-02",
+    "lineage": {
+      "upstream": ["raw.FunnelEvents"],
+      "downstream": ["mart.FunnelAnalysis"]
+    }
+  }
+]

--- a/tests/fixtures/glean/finance.InvoiceItem.json
+++ b/tests/fixtures/glean/finance.InvoiceItem.json
@@ -1,0 +1,47 @@
+[
+  {
+    "doc_id": "finance.InvoiceItem.schema",
+    "title": "finance.InvoiceItem Schema",
+    "doc_type": "schema",
+    "table_name": "finance.InvoiceItem",
+    "description": "Schema for invoice items",
+    "tags": ["finance"],
+    "url": "https://confluence.example.com/finance/InvoiceItem/schema",
+    "author": "fin_analyst",
+    "created_at": "2024-02-15",
+    "last_updated": "2024-05-22",
+    "row_count": 75000,
+    "columns": [
+      {"name": "invoice_id", "type": "STRING", "description": "Invoice id"},
+      {"name": "item_id", "type": "STRING", "description": "Item"},
+      {"name": "amount", "type": "DECIMAL", "description": "Amount"}
+    ],
+    "sample_query": "SELECT SUM(amount) FROM finance.InvoiceItem"
+  },
+  {
+    "doc_id": "finance.InvoiceItem.runbook",
+    "title": "InvoiceItem Pipeline Runbook",
+    "doc_type": "runbook",
+    "table_name": "finance.InvoiceItem",
+    "description": "Operations guide",
+    "tags": ["etl", "runbook"],
+    "url": "https://confluence.example.com/finance/InvoiceItem/runbook",
+    "author": "fin_engineer",
+    "created_at": "2024-03-01",
+    "last_updated": "2024-04-20",
+    "sample_query": "SELECT COUNT(*) FROM finance.InvoiceItem"
+  },
+  {
+    "doc_id": "finance.InvoiceItem.wiki",
+    "title": "InvoiceItem Wiki",
+    "doc_type": "wiki",
+    "table_name": "finance.InvoiceItem",
+    "description": "Usage info",
+    "tags": ["finance", "reference"],
+    "url": "https://confluence.example.com/finance/InvoiceItem/wiki",
+    "author": "fin_ops",
+    "created_at": "2024-02-20",
+    "last_updated": "2024-05-18",
+    "sample_query": "SELECT * FROM finance.InvoiceItem LIMIT 5"
+  }
+]

--- a/tests/fixtures/glean/marketing.CampaignSummary.json
+++ b/tests/fixtures/glean/marketing.CampaignSummary.json
@@ -1,0 +1,60 @@
+[
+  {
+    "doc_id": "marketing.CampaignSummary.schema",
+    "title": "marketing.CampaignSummary Schema",
+    "doc_type": "schema",
+    "table_name": "marketing.CampaignSummary",
+    "description": "Schema for marketing campaign summary",
+    "tags": ["marketing"],
+    "url": "https://confluence.example.com/marketing/CampaignSummary/schema",
+    "author": "mkt_analyst",
+    "created_at": "2024-02-01",
+    "last_updated": "2024-06-06",
+    "row_count": 45000,
+    "columns": [
+      {"name": "campaign_id", "type": "STRING", "description": "Campaign id"},
+      {"name": "impressions", "type": "INT", "description": "Impression count"},
+      {"name": "clicks", "type": "INT", "description": "Click count"}
+    ],
+    "sample_query": "SELECT campaign_id, clicks FROM marketing.CampaignSummary"
+  },
+  {
+    "doc_id": "marketing.CampaignSummary.wiki",
+    "title": "Campaign Summary Wiki",
+    "doc_type": "wiki",
+    "table_name": "marketing.CampaignSummary",
+    "description": "Overview and usage tips",
+    "tags": ["marketing", "reference"],
+    "url": "https://confluence.example.com/marketing/CampaignSummary/wiki",
+    "author": "mkt_ops",
+    "created_at": "2024-02-03",
+    "last_updated": "2024-05-30",
+    "sample_query": "SELECT campaign_id, impressions FROM marketing.CampaignSummary"
+  },
+  {
+    "doc_id": "marketing.CampaignSummary.dashboard",
+    "title": "Campaign Performance Dashboard",
+    "doc_type": "dashboard",
+    "table_name": "marketing.CampaignSummary",
+    "description": "Dashboard for campaign metrics",
+    "tags": ["dashboard"],
+    "url": "https://grafana.example.com/d/marketing/campaign",
+    "author": "mkt_manager",
+    "created_at": "2024-03-15",
+    "last_updated": "2024-04-30",
+    "metrics": ["CTR", "CPA"]
+  },
+  {
+    "doc_id": "marketing.CampaignSummary.runbook",
+    "title": "Campaign Summary Pipeline Runbook",
+    "doc_type": "runbook",
+    "table_name": "marketing.CampaignSummary",
+    "description": "ETL troubleshooting guide",
+    "tags": ["etl", "runbook"],
+    "url": "https://confluence.example.com/marketing/CampaignSummary/runbook",
+    "author": "mkt_engineer",
+    "created_at": "2024-02-10",
+    "last_updated": "2024-05-01",
+    "sample_query": "SELECT COUNT(*) FROM marketing.CampaignSummary"
+  }
+]

--- a/tests/fixtures/glean/sales.OrderHeader.json
+++ b/tests/fixtures/glean/sales.OrderHeader.json
@@ -1,0 +1,62 @@
+[
+  {
+    "doc_id": "sales.OrderHeader.schema",
+    "title": "sales.OrderHeader Schema",
+    "doc_type": "schema",
+    "table_name": "sales.OrderHeader",
+    "description": "Schema for order header table",
+    "tags": ["sales"],
+    "url": "https://confluence.example.com/sales/OrderHeader/schema",
+    "author": "sales_analyst",
+    "created_at": "2024-01-12",
+    "last_updated": "2024-05-20",
+    "row_count": 200000,
+    "columns": [
+      {"name": "order_id", "type": "STRING", "description": "Order id"},
+      {"name": "customer_id", "type": "STRING", "description": "Customer"},
+      {"name": "order_date", "type": "DATE", "description": "Order date"}
+    ],
+    "sample_query": "SELECT order_id FROM sales.OrderHeader LIMIT 10"
+  },
+  {
+    "doc_id": "sales.OrderHeader.wiki",
+    "title": "Order Header Wiki",
+    "doc_type": "wiki",
+    "table_name": "sales.OrderHeader",
+    "description": "Business documentation",
+    "tags": ["sales", "reference"],
+    "url": "https://confluence.example.com/sales/OrderHeader/wiki",
+    "author": "sales_ops",
+    "created_at": "2024-01-20",
+    "last_updated": "2024-05-28",
+    "sample_query": "SELECT COUNT(*) FROM sales.OrderHeader"
+  },
+  {
+    "doc_id": "sales.OrderHeader.lineage",
+    "title": "Order Header Lineage",
+    "doc_type": "lineage",
+    "table_name": "sales.OrderHeader",
+    "description": "Lineage for order header",
+    "tags": ["lineage"],
+    "url": "https://confluence.example.com/sales/OrderHeader/lineage",
+    "author": "data_engineer3",
+    "created_at": "2024-01-15",
+    "last_updated": "2024-06-04",
+    "lineage": {
+      "upstream": ["raw.Orders"],
+      "downstream": ["mart.OrderSummary"]
+    }
+  },
+  {
+    "doc_id": "sales.OrderHeader.notebook",
+    "title": "Order Header Analysis Notebook",
+    "doc_type": "notebook",
+    "table_name": "sales.OrderHeader",
+    "description": "Exploratory notebook for sales orders",
+    "tags": ["analysis"],
+    "url": "https://notebooks.example.com/sales/OrderHeader-analysis",
+    "author": "sales_analyst2",
+    "created_at": "2024-02-05",
+    "last_updated": "2024-05-15"
+  }
+]

--- a/tests/fixtures/glean/tracking.AdClickEvent.json
+++ b/tests/fixtures/glean/tracking.AdClickEvent.json
@@ -1,30 +1,76 @@
-{
-  "table_name": "tracking.AdClickEvent",
-  "description": "Sample table for tracking ad click events",
-  "columns": [
-    {
-      "name": "event_id",
-      "type": "STRING",
-      "description": "Unique identifier for the click event"
-    },
-    {
-      "name": "user_id",
-      "type": "STRING", 
-      "description": "User who clicked the ad"
-    },
-    {
-      "name": "ad_id",
-      "type": "STRING",
-      "description": "Advertisement identifier"
-    },
-    {
-      "name": "timestamp",
-      "type": "TIMESTAMP",
-      "description": "When the click occurred"
+[
+  {
+    "doc_id": "tracking.AdClickEvent.schema",
+    "title": "tracking.AdClickEvent Schema",
+    "doc_type": "schema",
+    "table_name": "tracking.AdClickEvent",
+    "description": "Schema for ad click events",
+    "tags": ["ads", "tracking"],
+    "url": "https://confluence.example.com/tracking/AdClickEvent/schema",
+    "author": "analyst1",
+    "created_at": "2024-01-10",
+    "last_updated": "2024-06-01",
+    "row_count": 1000000,
+    "columns": [
+      {"name": "event_id", "type": "STRING", "description": "Unique event id"},
+      {"name": "user_id", "type": "STRING", "description": "User identifier"},
+      {"name": "ad_id", "type": "STRING", "description": "Advertisement"},
+      {"name": "timestamp", "type": "TIMESTAMP", "description": "Click time"}
+    ],
+    "sample_query": "SELECT COUNT(*) FROM tracking.AdClickEvent WHERE DATE(timestamp)=CURRENT_DATE()"
+  },
+  {
+    "doc_id": "tracking.AdClickEvent.wiki",
+    "title": "Ad Click Event Usage Wiki",
+    "doc_type": "wiki",
+    "table_name": "tracking.AdClickEvent",
+    "description": "Business context and sample queries",
+    "tags": ["ads", "reference"],
+    "url": "https://confluence.example.com/tracking/AdClickEvent/wiki",
+    "author": "analyst2",
+    "created_at": "2024-01-15",
+    "last_updated": "2024-05-20",
+    "sample_query": "SELECT ad_id, COUNT(*) FROM tracking.AdClickEvent GROUP BY ad_id"
+  },
+  {
+    "doc_id": "tracking.AdClickEvent.lineage",
+    "title": "Ad Click Event Lineage",
+    "doc_type": "lineage",
+    "table_name": "tracking.AdClickEvent",
+    "description": "Upstream and downstream dependencies",
+    "tags": ["lineage"],
+    "url": "https://confluence.example.com/tracking/AdClickEvent/lineage",
+    "author": "data_engineer1",
+    "created_at": "2024-01-12",
+    "last_updated": "2024-06-05",
+    "lineage": {
+      "upstream": ["raw.AdClicks"],
+      "downstream": ["mart.AdClickDaily"]
     }
-  ],
-  "sample_queries": [
-    "SELECT COUNT(*) FROM tracking.AdClickEvent WHERE DATE(timestamp) = CURRENT_DATE()",
-    "SELECT user_id, COUNT(*) as clicks FROM tracking.AdClickEvent GROUP BY user_id"
-  ]
-} 
+  },
+  {
+    "doc_id": "tracking.AdClickEvent.dashboard",
+    "title": "Ad Click Metrics Dashboard",
+    "doc_type": "dashboard",
+    "table_name": "tracking.AdClickEvent",
+    "description": "Grafana dashboard for ad click metrics",
+    "tags": ["metrics", "dashboard"],
+    "url": "https://grafana.example.com/d/ads/clicks",
+    "author": "analyst3",
+    "created_at": "2024-03-01",
+    "last_updated": "2024-05-30",
+    "metrics": ["CTR", "CPA"]
+  },
+  {
+    "doc_id": "tracking.AdClickEvent.notebook",
+    "title": "Ad Click Exploratory Notebook",
+    "doc_type": "notebook",
+    "table_name": "tracking.AdClickEvent",
+    "description": "Jupyter notebook for deep dive",
+    "tags": ["analysis"],
+    "url": "https://notebooks.example.com/tracking/AdClickEvent-analysis",
+    "author": "analyst4",
+    "created_at": "2024-02-10",
+    "last_updated": "2024-05-18"
+  }
+]

--- a/tests/fixtures/glean/tracking.PageView.json
+++ b/tests/fixtures/glean/tracking.PageView.json
@@ -1,0 +1,64 @@
+[
+  {
+    "doc_id": "tracking.PageView.schema",
+    "title": "tracking.PageView Schema",
+    "doc_type": "schema",
+    "table_name": "tracking.PageView",
+    "description": "Schema for page view events",
+    "tags": ["tracking"],
+    "url": "https://confluence.example.com/tracking/PageView/schema",
+    "author": "analyst1",
+    "created_at": "2024-01-05",
+    "last_updated": "2024-05-25",
+    "row_count": 5000000,
+    "columns": [
+      {"name": "event_id", "type": "STRING", "description": "Event id"},
+      {"name": "user_id", "type": "STRING", "description": "User"},
+      {"name": "page", "type": "STRING", "description": "Page path"},
+      {"name": "timestamp", "type": "TIMESTAMP", "description": "View time"}
+    ],
+    "sample_query": "SELECT page, COUNT(*) FROM tracking.PageView GROUP BY page"
+  },
+  {
+    "doc_id": "tracking.PageView.runbook",
+    "title": "PageView ETL Runbook",
+    "doc_type": "runbook",
+    "table_name": "tracking.PageView",
+    "description": "Operational runbook for pipeline",
+    "tags": ["etl", "runbook"],
+    "url": "https://confluence.example.com/tracking/PageView/runbook",
+    "author": "ops1",
+    "created_at": "2024-02-01",
+    "last_updated": "2024-04-15",
+    "sample_query": "SELECT COUNT(*) FROM tracking.PageView WHERE timestamp >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)"
+  },
+  {
+    "doc_id": "tracking.PageView.wiki",
+    "title": "PageView Usage Wiki",
+    "doc_type": "wiki",
+    "table_name": "tracking.PageView",
+    "description": "Business context for page views",
+    "tags": ["tracking", "reference"],
+    "url": "https://confluence.example.com/tracking/PageView/wiki",
+    "author": "analyst2",
+    "created_at": "2024-01-20",
+    "last_updated": "2024-05-10",
+    "sample_query": "SELECT user_id, COUNT(*) FROM tracking.PageView GROUP BY user_id"
+  },
+  {
+    "doc_id": "tracking.PageView.lineage",
+    "title": "PageView Lineage",
+    "doc_type": "lineage",
+    "table_name": "tracking.PageView",
+    "description": "Upstream/downstream lineage",
+    "tags": ["lineage"],
+    "url": "https://confluence.example.com/tracking/PageView/lineage",
+    "author": "data_engineer2",
+    "created_at": "2024-01-08",
+    "last_updated": "2024-06-03",
+    "lineage": {
+      "upstream": ["raw.PageViews"],
+      "downstream": ["mart.PageViewDaily"]
+    }
+  }
+]

--- a/tests/fixtures/glean/user.ProfileSnapshot.json
+++ b/tests/fixtures/glean/user.ProfileSnapshot.json
@@ -1,0 +1,34 @@
+[
+  {
+    "doc_id": "user.ProfileSnapshot.schema",
+    "title": "user.ProfileSnapshot Schema",
+    "doc_type": "schema",
+    "table_name": "user.ProfileSnapshot",
+    "description": "Schema for user profile snapshots",
+    "tags": ["user"],
+    "url": "https://confluence.example.com/user/ProfileSnapshot/schema",
+    "author": "user_team",
+    "created_at": "2024-03-01",
+    "last_updated": "2024-05-29",
+    "row_count": 800000,
+    "columns": [
+      {"name": "user_id", "type": "STRING", "description": "User id"},
+      {"name": "snapshot_date", "type": "DATE", "description": "Snapshot date"},
+      {"name": "status", "type": "STRING", "description": "Status"}
+    ],
+    "sample_query": "SELECT * FROM user.ProfileSnapshot WHERE status='active'"
+  },
+  {
+    "doc_id": "user.ProfileSnapshot.wiki",
+    "title": "ProfileSnapshot Wiki",
+    "doc_type": "wiki",
+    "table_name": "user.ProfileSnapshot",
+    "description": "Documentation for user snapshots",
+    "tags": ["user", "reference"],
+    "url": "https://confluence.example.com/user/ProfileSnapshot/wiki",
+    "author": "user_ops",
+    "created_at": "2024-03-10",
+    "last_updated": "2024-05-19",
+    "sample_query": "SELECT COUNT(*) FROM user.ProfileSnapshot"
+  }
+]

--- a/tests/table_research/test_glean_search.py
+++ b/tests/table_research/test_glean_search.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import os
+import json
+import pytest
+
+from src.my_agents.table_research.tools import GleanSearch
+
+
+@pytest.fixture(autouse=True)
+def _set_stub_env(monkeypatch):
+    monkeypatch.setenv("USE_GLEAN_STUB", "true")
+
+
+def test_happy_path_retrieval():
+    search = GleanSearch(Path("tests/fixtures/glean"))
+    results = search.search("marketing.CampaignSummary", top_k=1)
+    assert results
+    first = results[0]
+    for field in [
+        "doc_id",
+        "title",
+        "doc_type",
+        "table_name",
+        "description",
+        "tags",
+        "url",
+    ]:
+        assert field in first
+
+
+def test_schema_columns_non_empty():
+    search = GleanSearch()
+    docs = search.search("tracking.AdClickEvent")
+    schema_docs = [d for d in docs if d["doc_type"] == "schema"]
+    assert schema_docs and schema_docs[0]["columns"]
+
+
+def test_lineage_has_edges():
+    search = GleanSearch()
+    docs = search.search("tracking.PageView")
+    lineage_docs = [d for d in docs if d["doc_type"] == "lineage"]
+    assert lineage_docs
+    lineage = lineage_docs[0]["lineage"]
+    assert lineage["upstream"] or lineage["downstream"]
+
+
+def test_missing_table_error():
+    search = GleanSearch()
+    with pytest.raises(FileNotFoundError):
+        search.search("nonexistent.Table")
+
+
+def test_no_live_sdk_reference():
+    forbidden = []
+    for path in Path("src").rglob("*.py"):
+        text = path.read_text()
+        if "GleanAPIClient" in text:
+            forbidden.append(path)
+    assert not forbidden, f"Forbidden import found in: {forbidden}"

--- a/tests/table_research/test_placeholder.py
+++ b/tests/table_research/test_placeholder.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
-# SPDX-License-Identifier: MIT
-
-"""Placeholder test for table research module."""
-
-
-def test_placeholder():
-    """Placeholder test to ensure pytest runs successfully."""
-    assert True


### PR DESCRIPTION
## Summary
- introduce stub-based GleanSearch tool
- enrich fixture corpus with seven realistic files
- document fixture schema and stub usage
- add tests covering search tool behaviour
- update changelog

## Testing
- `black --check --preview .`
- `ruff check .`
- `mypy --strict src/my_agents/table_research/tools/glean_search.py`
- `PYTHONPATH=. pytest -o addopts='' tests/table_research/test_glean_search.py -q`