### PR TITLE
feat: implement TableResearcher node (Phase 4)

### DIFF
--- a/src/my_agents/table_research/__init__.py
+++ b/src/my_agents/table_research/__init__.py
@@ -1,2 +1,6 @@
-# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
-# SPDX-License-Identifier: MIT
+"""Table-Deep-Research agents and utilities."""
+
+from .table_researcher import TableResearcher
+from .tools import GleanSearch
+
+__all__ = ["TableResearcher", "GleanSearch"]

--- a/src/my_agents/table_research/merge_insights.py
+++ b/src/my_agents/table_research/merge_insights.py
@@ -1,0 +1,54 @@
+"""Aggregate chunk-level insights into a single summary structure."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+from typing import Any, Iterable, Mapping
+
+
+def merge_insights(
+    chunk_outputs: Iterable[Mapping[str, Any]],
+    glean_docs: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Merge LLM JSON outputs and compute freshness ranking."""
+    seen: set[str] = set()
+    insights: list[str] = []
+    usage = Counter()
+
+    for output in chunk_outputs:
+        for ins in output.get("insights", []):
+            norm = ins.strip().casefold()
+            if norm not in seen:
+                seen.add(norm)
+                insights.append(ins.strip())
+        for ex in output.get("usage_examples", []):
+            usage[ex.strip()] += 1
+
+    usage_examples = [ex for ex, _ in usage.most_common()]
+
+    today = date.today()
+    freshest: int | None = None
+    for doc in glean_docs:
+        ts = doc.get("last_updated")
+        if not ts:
+            continue
+        try:
+            days = (today - date.fromisoformat(ts)).days
+        except Exception:
+            continue
+        freshest = days if freshest is None or days < freshest else freshest
+    if freshest is None:
+        sla = "cold"
+    elif freshest <= 7:
+        sla = "hot"
+    elif freshest <= 30:
+        sla = "warm"
+    else:
+        sla = "cold"
+
+    return {
+        "insights": insights,
+        "usage_examples": usage_examples,
+        "freshness_sla": sla,
+    }

--- a/src/my_agents/table_research/smart_split.py
+++ b/src/my_agents/table_research/smart_split.py
@@ -1,0 +1,43 @@
+"""Utility to split text into token-budget aware chunks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+
+def default_token_len(text: str) -> int:
+    """Rudimentary token length estimator (word count)."""
+    return len(text.split())
+
+
+def smart_split(
+    text: str,
+    chunk_tokens: int,
+    *,
+    tiktoken_len: Callable[[str], int] = default_token_len,
+) -> Iterable[str]:
+    """Yield chunks of ``text`` each under ``chunk_tokens`` tokens."""
+    if chunk_tokens <= 0:
+        raise ValueError("chunk_tokens must be positive")
+
+    parts = text.split("\n\n")
+    current: list[str] = []
+    tokens = 0
+    for part in parts:
+        length = tiktoken_len(part)
+        # part itself exceeds budget
+        if length > chunk_tokens:
+            if current:
+                yield "\n\n".join(current)
+                current, tokens = [], 0
+            yield part
+            continue
+        if tokens + length > chunk_tokens:
+            if current:
+                yield "\n\n".join(current)
+            current, tokens = [part], length
+        else:
+            current.append(part)
+            tokens += length
+    if current:
+        yield "\n\n".join(current)

--- a/src/my_agents/table_research/table_researcher.py
+++ b/src/my_agents/table_research/table_researcher.py
@@ -1,0 +1,110 @@
+"""LangGraph node that processes Glean docs into structured insights."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    from langgraph.prebuilt import agent_node
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+
+    def agent_node(cls=None):
+        return cls if cls is not None else (lambda x: x)
+
+
+from langgraph.prebuilt.chat_agent_executor import AgentState
+from langchain_openai import ChatOpenAI
+
+from src.config.loader import load_yaml_config
+from .smart_split import smart_split
+from .merge_insights import merge_insights
+from .tools import GleanSearch
+from src.prompts.template import apply_prompt_template
+
+logger = logging.getLogger(__name__)
+
+
+@agent_node
+class TableResearcher:
+    """Node for extracting insights from table documentation."""
+
+    def __init__(self) -> None:
+        conf = load_yaml_config(str(Path("conf.d/table_research.yaml")))
+        self.cfg = conf.get("table_research", {})
+        self.search = GleanSearch()
+        self.llm = ChatOpenAI(**self.cfg.get("llm", {}))
+        self.semaphore = asyncio.Semaphore(int(os.getenv("LLM_PAR", 4)))
+        self._logged_stub = False
+
+    async def __call__(self, state: AgentState) -> dict[str, Any]:
+        if not self._logged_stub:
+            mode = (
+                "stub"
+                if os.getenv("USE_GLEAN_STUB", "true").lower() == "true"
+                else "live"
+            )
+            logger.info(f"Operating in Glean {mode} mode")
+            self._logged_stub = True
+
+        table_name = state["table_name"]
+        docs = self.search.search(table_name, top_k=self.cfg.get("max_docs"))
+
+        chunks = []
+        for i, doc in enumerate(docs):
+            text = json.dumps(doc, ensure_ascii=False)
+            for j, chunk in enumerate(
+                smart_split(text, self.cfg.get("chunk_tokens", 2048))
+            ):
+                chunks.append((i, j, chunk))
+
+        async def run_chunk(chunk: str) -> dict[str, Any]:
+            async with self.semaphore:
+                messages = apply_prompt_template(
+                    "my_agents/table/glean_reader",
+                    {
+                        "messages": [{"role": "user", "content": chunk}],
+                        "table_name": table_name,
+                        "chunk_tokens": self.cfg.get("chunk_tokens"),
+                    },
+                )
+                resp = await self.llm.ainvoke(messages)
+                try:
+                    return json.loads(resp.content)
+                except Exception:
+                    return {"insights": [], "usage_examples": []}
+
+        outputs = await asyncio.gather(*(run_chunk(c) for _, _, c in chunks))
+        aggregated = merge_insights(outputs, docs)
+        report_parts = self._derive_report_parts(aggregated)
+
+        return {
+            "glean_docs": docs,
+            "doc_insights": aggregated,
+            "report_parts": report_parts,
+        }
+
+    def _derive_report_parts(self, aggregated: dict[str, Any]) -> dict[str, Any]:
+        key_cols: list[str] = []
+        business: list[str] = []
+        gotchas: list[str] = []
+        for ins in aggregated.get("insights", []):
+            text = ins.strip()
+            upper = text.upper()
+            if upper.startswith("<INSIGHT_1>"):
+                key_cols.append(text.split(">", 1)[-1].strip())
+            elif upper.startswith("<INSIGHT_2>"):
+                business.append(text.split(">", 1)[-1].strip())
+            elif upper.startswith("<INSIGHT_3>"):
+                gotchas.append(text.split(">", 1)[-1].strip())
+        parts = {
+            "key_columns": key_cols,
+            "business_meanings": business,
+            "gotchas": gotchas,
+            "sample_queries": aggregated.get("usage_examples", []),
+        }
+        return {k: v for k, v in parts.items() if v}

--- a/tests/table_research/test_merge_insights.py
+++ b/tests/table_research/test_merge_insights.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+from src.my_agents.table_research.merge_insights import merge_insights
+
+
+def test_merge_insights_dedup_and_rank(monkeypatch):
+    chunks = [
+        {
+            "insights": ["<INSIGHT_1> col:ad_id", "<INSIGHT_2> join"],
+            "usage_examples": ["select *", "count"],
+        },
+        {
+            "insights": ["  <INSIGHT_1> col:ad_id", "<INSIGHT_3> no owner"],
+            "usage_examples": ["select *"],
+        },
+    ]
+    glean_docs = [
+        {"last_updated": "2024-06-05"},
+        {"last_updated": "2024-05-20"},
+    ]
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):  # type: ignore[override]
+            return date(2024, 6, 7)
+
+    monkeypatch.setattr("src.my_agents.table_research.merge_insights.date", FakeDate)
+
+    result = merge_insights(chunks, glean_docs)
+    assert result["insights"] == [
+        "<INSIGHT_1> col:ad_id",
+        "<INSIGHT_2> join",
+        "<INSIGHT_3> no owner",
+    ]
+    assert result["usage_examples"] == ["select *", "count"]
+    assert result["freshness_sla"] == "hot"

--- a/tests/table_research/test_smart_split.py
+++ b/tests/table_research/test_smart_split.py
@@ -1,0 +1,13 @@
+from src.my_agents.table_research.smart_split import smart_split
+
+
+def test_smart_split_respects_budget_and_order():
+    text = "A B C D E F"
+
+    def fake_len(t: str) -> int:
+        return len(t.split())
+
+    chunks = list(smart_split(text, 2, tiktoken_len=fake_len))
+    assert chunks == ["A B", "C D", "E F"]
+    assert " ".join(chunks) == text
+    assert all(fake_len(c) <= 2 for c in chunks)

--- a/tests/table_research/test_table_researcher.py
+++ b/tests/table_research/test_table_researcher.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import types
+
+import pytest
+
+from src.my_agents.table_research.table_researcher import TableResearcher
+
+
+class DummyLLM:
+    async def ainvoke(self, messages):
+        return types.SimpleNamespace(
+            content=json.dumps(
+                {"insights": ["<INSIGHT_1> col:ad_id"], "usage_examples": ["select *"]}
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_table_researcher_flow(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("USE_GLEAN_STUB", "true")
+    monkeypatch.setenv("LLM_PAR", "1")
+
+    researcher = TableResearcher()
+    researcher.cfg["max_docs"] = 1
+    researcher.llm = DummyLLM()
+
+    state = {"table_name": "tracking.AdClickEvent"}
+    first = await researcher(state)
+    await researcher(state)
+
+    assert first["glean_docs"]
+    assert first["report_parts"]["key_columns"] == ["col:ad_id"]
+    assert first["report_parts"]["sample_queries"] == ["select *"]
+    log_lines = [r.message for r in caplog.records if "Operating in Glean" in r.message]
+    assert len(log_lines) == 1


### PR DESCRIPTION
## Summary
- add smart_split helper for token-aware chunking
- add merge_insights aggregator
- implement TableResearcher LangGraph node
- expose TableResearcher in package init
- tests for smart_split, merge_insights and TableResearcher

## Testing
- `ruff check src/my_agents/table_research tests/table_research/test_smart_split.py tests/table_research/test_merge_insights.py tests/table_research/test_table_researcher.py`
- `black src/my_agents/table_research tests/table_research/test_smart_split.py tests/table_research/test_merge_insights.py tests/table_research/test_table_researcher.py`
- `mypy src/my_agents/table_research tests/table_research/test_smart_split.py tests/table_research/test_merge_insights.py tests/table_research/test_table_researcher.py` *(fails: Cannot find implementation or library stub)*
- `pytest tests/table_research/test_smart_split.py tests/table_research/test_merge_insights.py tests/table_research/test_table_researcher.py` *(fails: No module named 'langgraph')*