### PR TITLE
feat: add Reporter node for Table-Deep-Research workflow

### DIFF
--- a/src/my_agents/table_research/__init__.py
+++ b/src/my_agents/table_research/__init__.py
@@ -1,6 +1,11 @@
 """Table-Deep-Research agents and utilities."""
 
-from .table_researcher import TableResearcher
+try:
+    from .table_researcher import TableResearcher
+except Exception:  # pragma: no cover - optional when deps missing
+    TableResearcher = None  # type: ignore[misc]
+
+from .table_reporter import TableReporter
 from .tools import GleanSearch
 
-__all__ = ["TableResearcher", "GleanSearch"]
+__all__ = ["TableResearcher", "TableReporter", "GleanSearch"]

--- a/src/my_agents/table_research/table_reporter.py
+++ b/src/my_agents/table_research/table_reporter.py
@@ -1,0 +1,82 @@
+"""LangGraph node that assembles a Markdown table guide."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    from langgraph.prebuilt.chat_agent_executor import AgentState
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+    AgentState = Mapping[str, Any]  # type: ignore[misc, assignment]
+
+try:  # pragma: no cover - optional dependency
+    from jinja2 import Environment, FileSystemLoader, StrictUndefined
+except Exception:  # pragma: no cover - jinja2 missing
+    Environment = None  # type: ignore
+    FileSystemLoader = StrictUndefined = None  # type: ignore
+
+try:
+    from langgraph.prebuilt import agent_node  # type: ignore
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+
+    def agent_node(cls=None):
+        return cls if cls is not None else (lambda x: x)
+
+
+logger = logging.getLogger(__name__)
+TEMPLATE_PATH = Path("prompts/my_agents/table/reporter.md")
+
+try:  # pragma: no cover - optional dependency
+    import mdformat
+except Exception:  # pragma: no cover - missing formatter
+    mdformat = None  # type: ignore
+
+
+@agent_node
+class TableReporter:
+    """Node to compile research insights into a table guide."""
+
+    def __call__(self, state: AgentState | Mapping[str, Any]) -> dict[str, Any]:
+        table_name = state.get("table_name", "unknown")
+        locale = state.get("locale", "en-US")
+        report_parts = state.get("report_parts")
+
+        if not report_parts:
+            guide = "No insights found\n"
+        else:
+            if Environment is None:
+                guide = TEMPLATE_PATH.read_text()
+                for key, val in {
+                    "table_name": table_name,
+                    "locale": locale,
+                    **report_parts,
+                }.items():
+                    guide = guide.replace(f"{{{{ {key} }}}}", str(val))
+            else:
+                env = Environment(
+                    loader=FileSystemLoader(str(TEMPLATE_PATH.parent)),
+                    autoescape=False,
+                    undefined=StrictUndefined,
+                    trim_blocks=True,
+                    lstrip_blocks=True,
+                )
+                template = env.get_template(TEMPLATE_PATH.name)
+                guide = template.render(
+                    table_name=table_name, locale=locale, **report_parts
+                )
+
+            guide = guide.replace("# Key Columns", "## Key Columns")
+            if mdformat is not None:
+                try:
+                    guide = mdformat.text(guide)
+                except Exception as exc:  # pragma: no cover - formatting failure
+                    logger.warning(f"mdformat failed: {exc}")
+            if not guide.endswith("\n"):
+                guide += "\n"
+
+        result = dict(state)
+        result["table_guide_md"] = guide
+        logger.info(f"[Reporter] Assembled guide for {table_name} ({len(guide)} chars)")
+        return result

--- a/tests/table_research/test_table_reporter.py
+++ b/tests/table_research/test_table_reporter.py
@@ -1,0 +1,57 @@
+import logging
+import types
+
+from src.my_agents.table_research.table_reporter import TableReporter
+
+
+def _setup_mdformat(monkeypatch, fn):
+    """Replace mdformat.text with given function."""
+    module = __import__(
+        "src.my_agents.table_research.table_reporter",
+        fromlist=["mdformat"],
+    )
+    monkeypatch.setattr(module, "mdformat", types.SimpleNamespace(text=fn))
+
+
+def test_reporter_happy_path(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
+    def identity(text: str) -> str:
+        return text
+
+    _setup_mdformat(monkeypatch, identity)
+
+    reporter = TableReporter()
+    state = {
+        "table_name": "demo.Table",
+        "report_parts": {"key_columns": ["id"], "sample_queries": ["select 1"]},
+    }
+    out = reporter(state)
+
+    assert out["table_guide_md"].startswith("# Overview")
+    assert "## Key Columns" in out["table_guide_md"]
+    assert out["table_guide_md"].endswith("\n")
+    log_lines = [r.message for r in caplog.records if "[Reporter]" in r.message]
+    assert len(log_lines) == 1
+
+
+def test_reporter_empty_parts():
+    reporter = TableReporter()
+    out = reporter({"table_name": "demo.Table"})
+    assert out["table_guide_md"] == "No insights found\n"
+
+
+def test_mdformat_failure(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+
+    def boom(_: str) -> str:
+        raise RuntimeError("fail")
+
+    _setup_mdformat(monkeypatch, boom)
+
+    reporter = TableReporter()
+    state = {"table_name": "demo.Table", "report_parts": {"key_columns": ["id"]}}
+    out = reporter(state)
+    assert out["table_guide_md"].startswith("# Overview")
+    warn_lines = [r.message for r in caplog.records if "mdformat failed" in r.message]
+    assert len(warn_lines) == 1


### PR DESCRIPTION
## Summary
- implement `TableReporter` node to assemble Markdown guides
- expose reporter in `table_research` package
- test reporter behaviour and failures
- fallback implementations for missing dependencies

## Testing
- `ruff check src/my_agents/table_research/table_reporter.py src/my_agents/table_research/__init__.py tests/table_research/test_table_reporter.py`
- `black src/my_agents/table_research/table_reporter.py src/my_agents/table_research/__init__.py tests/table_research/test_table_reporter.py`
- `PYTHONPATH=$PWD pytest -q tests/table_research/test_table_reporter.py -vv`