### PR TITLE
Implement table research graph and e2e flow

### DIFF
--- a/api/table_guide.py
+++ b/api/table_guide.py
@@ -1,0 +1,16 @@
+"""HTTP route scaffold for table guide generation."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from my_agents.table_research import run_table_deep_research
+
+
+table_guide_router = APIRouter()
+
+
+@table_guide_router.get("/table_guide")
+async def get_table_guide(table: str):
+    guide = run_table_deep_research(table)
+    return {"table": table, "guide": guide}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ extend-exclude = '''
 # in the root of the project.
 ^/build/
 '''
+
+[tool.poetry.scripts]
+tdr-table = "my_agents.table_research:cli_main"

--- a/src/my_agents/table_research/__init__.py
+++ b/src/my_agents/table_research/__init__.py
@@ -6,6 +6,30 @@ except Exception:  # pragma: no cover - optional when deps missing
     TableResearcher = None  # type: ignore[misc]
 
 from .table_reporter import TableReporter
+from .table_planner import TablePlanner
 from .tools import GleanSearch
+from .graph import run_graph
 
-__all__ = ["TableResearcher", "TableReporter", "GleanSearch"]
+def run_table_deep_research(table_name: str, *, max_docs: int | None = None) -> str:
+    """Run the table-deep-research workflow and return Markdown text."""
+    return run_graph(table_name, max_docs=max_docs)
+
+def cli_main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Table Deep Research")
+    parser.add_argument("table_name")
+    parser.add_argument("--max-docs", type=int, default=None)
+    args = parser.parse_args()
+
+    md = run_table_deep_research(args.table_name, max_docs=args.max_docs)
+    print(md)
+
+__all__ = [
+    "TablePlanner",
+    "TableResearcher",
+    "TableReporter",
+    "GleanSearch",
+    "run_table_deep_research",
+    "cli_main",
+]

--- a/src/my_agents/table_research/graph.py
+++ b/src/my_agents/table_research/graph.py
@@ -1,0 +1,95 @@
+"""LangGraph workflow wiring for Table-Deep-Research agents."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from langgraph.graph import END, START, StateGraph
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+
+    class _DummyWorkflow:
+        def __init__(self, nodes):
+            self.nodes = nodes
+
+        def invoke(self, state: dict[str, Any]) -> dict[str, Any]:
+            for node in self.nodes:
+                state.update(node(state))
+            return state
+
+    class StateGraph:
+        def __init__(self, _state):
+            self._nodes = []
+
+        def add_node(self, _name: str, node):
+            self._nodes.append(node)
+
+        def add_edge(self, *_args, **_kwargs):
+            pass
+
+        def compile(self, max_parallel: int | None = None):  # pragma: no cover - simple stub
+            return _DummyWorkflow(self._nodes)
+
+    START = END = None  # type: ignore
+
+from .table_planner import TablePlanner
+from .table_researcher import TableResearcher
+from .table_reporter import TableReporter
+from src.config.loader import load_yaml_config
+from .utils import log_stub_once
+
+logger = logging.getLogger("tdr.table_graph")
+
+
+@dataclass
+class TableResearchState:
+    """Aggregate state for the table-deep-research workflow."""
+
+    table_name: str
+    plan: list[dict[str, Any]] | None = None
+    doc_chunks: list[str] | None = None
+    insights: dict[str, Any] | None = None
+    report_parts: dict[str, Any] | None = None
+    markdown_report: str | None = None
+
+
+def build_graph(max_parallel: int = 4):
+    """Create and compile the table research graph."""
+    planner = TablePlanner()
+    researcher = TableResearcher()
+    reporter = TableReporter()
+
+    builder = StateGraph(TableResearchState)
+    builder.add_node("planner", planner)
+    builder.add_node("researcher", researcher)
+    builder.add_node("reporter", reporter)
+    builder.add_edge(START, "planner")
+    builder.add_edge("planner", "researcher")
+    builder.add_edge("researcher", "reporter")
+    builder.add_edge("reporter", END)
+    return builder.compile(max_parallel=max_parallel)
+
+
+def run_graph(table_name: str, *, max_docs: int | None = None) -> str:
+    """Execute the graph and return the Markdown report."""
+    conf = load_yaml_config("conf.d/table_research.yaml").get("table_research", {})
+    if max_docs is not None:
+        conf["max_docs"] = max_docs
+    use_stub = conf.get("glean", {}).get("use_stub", True)
+    logger.info(
+        "Starting graph for %s (max_docs=%s, use_stub=%s)",
+        table_name,
+        conf.get("max_docs"),
+        use_stub,
+    )
+
+    graph = build_graph()
+    start = time.monotonic()
+    result = graph.invoke({"table_name": table_name})
+    elapsed = time.monotonic() - start
+    logger.info("Generated guide for %s in %.2fs", table_name, elapsed)
+    return result.get("markdown_report", "")
+

--- a/src/my_agents/table_research/table_planner.py
+++ b/src/my_agents/table_research/table_planner.py
@@ -1,0 +1,58 @@
+"""LangGraph node that creates a research plan for a table."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+try:
+    from langgraph.prebuilt import agent_node
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+    def agent_node(cls=None):
+        return cls if cls is not None else (lambda x: x)
+
+try:
+    from langgraph.prebuilt.chat_agent_executor import AgentState
+except Exception:  # pragma: no cover - fallback when langgraph not installed
+    AgentState = dict  # type: ignore[misc, assignment]
+
+from langchain_openai import ChatOpenAI
+
+from src.config.loader import load_yaml_config
+from src.prompts.template import apply_prompt_template
+from .utils import log_stub_once
+
+logger = logging.getLogger(__name__)
+
+
+@agent_node
+class TablePlanner:
+    """Node that generates the analysis plan."""
+
+    def __init__(self) -> None:
+        conf = load_yaml_config(str(Path("conf.d/table_research.yaml")))
+        self.cfg = conf.get("table_research", {})
+        self.llm = ChatOpenAI(**self.cfg.get("llm", {}))
+        self._logged = False
+
+    async def __call__(self, state: AgentState) -> dict[str, Any]:
+        if not self._logged:
+            log_stub_once(logger)
+            self._logged = True
+        table_name = state["table_name"]
+        messages = apply_prompt_template(
+            "my_agents/table/plan",
+            {
+                "messages": [],
+                "table_name": table_name,
+                "chunk_tokens": self.cfg.get("chunk_tokens"),
+            },
+        )
+        resp = await self.llm.ainvoke(messages)
+        try:
+            plan = json.loads(resp.content)
+        except Exception:
+            plan = []
+        return {"plan": plan}

--- a/src/my_agents/table_research/table_reporter.py
+++ b/src/my_agents/table_research/table_reporter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any, Mapping
+from .utils import log_stub_once
 
 try:
     from langgraph.prebuilt.chat_agent_executor import AgentState
@@ -39,6 +40,7 @@ class TableReporter:
     """Node to compile research insights into a table guide."""
 
     def __call__(self, state: AgentState | Mapping[str, Any]) -> dict[str, Any]:
+        log_stub_once(logger)
         table_name = state.get("table_name", "unknown")
         locale = state.get("locale", "en-US")
         report_parts = state.get("report_parts")
@@ -77,6 +79,6 @@ class TableReporter:
                 guide += "\n"
 
         result = dict(state)
-        result["table_guide_md"] = guide
+        result["markdown_report"] = guide
         logger.info(f"[Reporter] Assembled guide for {table_name} ({len(guide)} chars)")
         return result

--- a/src/my_agents/table_research/table_researcher.py
+++ b/src/my_agents/table_research/table_researcher.py
@@ -24,6 +24,7 @@ from src.config.loader import load_yaml_config
 from .smart_split import smart_split
 from .merge_insights import merge_insights
 from .tools import GleanSearch
+from .utils import log_stub_once
 from src.prompts.template import apply_prompt_template
 
 logger = logging.getLogger(__name__)
@@ -43,12 +44,7 @@ class TableResearcher:
 
     async def __call__(self, state: AgentState) -> dict[str, Any]:
         if not self._logged_stub:
-            mode = (
-                "stub"
-                if os.getenv("USE_GLEAN_STUB", "true").lower() == "true"
-                else "live"
-            )
-            logger.info(f"Operating in Glean {mode} mode")
+            log_stub_once(logger)
             self._logged_stub = True
 
         table_name = state["table_name"]

--- a/src/my_agents/table_research/tools/__init__.py
+++ b/src/my_agents/table_research/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tools for table research module."""
 
 from .glean_search import GleanSearch
+from ..utils import log_stub_once
 
-__all__ = ["GleanSearch"]
+__all__ = ["GleanSearch", "log_stub_once"]

--- a/src/my_agents/table_research/utils.py
+++ b/src/my_agents/table_research/utils.py
@@ -1,0 +1,17 @@
+"""Utility helpers for Table-Deep-Research agents."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_logged_stub = False
+
+
+def log_stub_once(logger: logging.Logger) -> None:
+    """Log the Glean stub mode at most once."""
+    global _logged_stub
+    if not _logged_stub:
+        mode = "stub" if os.getenv("USE_GLEAN_STUB", "true").lower() == "true" else "live"
+        logger.info(f"Operating in Glean {mode} mode")
+        _logged_stub = True

--- a/tests/table_research/test_e2e.py
+++ b/tests/table_research/test_e2e.py
@@ -1,0 +1,21 @@
+import logging
+import os
+
+import pytest
+
+from my_agents.table_research import run_table_deep_research
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("table", ["tracking.AdClickEvent", "marketing.CampaignSummary"])
+def test_run_table_deep_research_e2e(monkeypatch, caplog, table):
+    if os.getenv("USE_GLEAN_STUB", "true").lower() != "true":
+        pytest.skip("Glean stub disabled")
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("USE_GLEAN_STUB", "true")
+
+    md = run_table_deep_research(table)
+    assert md.startswith("# ")
+    assert "## Key Columns" in md
+    assert any("stub mode" in r.message.lower() for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- add TableResearchState and LangGraph wiring
- implement table planner, reporter and runner
- expose `run_table_deep_research` API and CLI
- provide FastAPI route scaffold
- add integration test for end-to-end table research

## Testing
- `make lint` *(fails: Failed to download `langsmith`)*
- `make test` *(fails: Failed to download `rpds-py`)*
- `make coverage` *(fails: Failed to download `langchain-community`)*